### PR TITLE
Improve regex search for AssemblyInformationalVersion

### DIFF
--- a/src/MSBuild.AssemblyVersion/targets/MSBuild.AssemblyVersion.targets
+++ b/src/MSBuild.AssemblyVersion/targets/MSBuild.AssemblyVersion.targets
@@ -67,7 +67,7 @@
         
         if(!string.IsNullOrEmpty(this.AssemblyInformationalVersion))
         {
-          txt = Regex.Replace(txt, @"(?m)(?<=^\[assembly:\sAssemblyInformationalVersion\("")[0-9a-zA-Z\.\-]+(?=""\)\])", this.AssemblyInformationalVersion);
+          txt = Regex.Replace(txt, @"(?m)(?<=^\[assembly:\sAssemblyInformationalVersion\("")[^""]*(?=""\)\])", this.AssemblyInformationalVersion);
         }
 
         new FileInfo(this.VersionFilePath).IsReadOnly = false;


### PR DESCRIPTION
The replacement for AssemblyInformationalVersion didn't work in two cases:
- `[assembly: AssemblyInformationalVersion("")]` (empty string)
- `[assembly: AssemblyInformationalVersion("abc def")]` (containing spaces, and/or other special characters)

I changed the regex to allow those two use cases as well.